### PR TITLE
Receive call and forward to sip or phone with failover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ chat
 npm-debug.log
 *.mp3
 *.key
+.c9

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For some of the examples you will need to [buy a number](https://dashboard.nexmo
 | ---------------------------------------- | ---------------------------------------- |
 | [How to Make an Outbound Text-to-Speech Phone Call with Node.js](https://www.nexmo.com/blog/2017/01/12/make-outbound-text-speech-phone-call-node-js-dr/) | [make-calls.js](voice/make-call.js)      |
 | [How to Handle Inbound Phone Calls with Node.js](https://www.nexmo.com/blog/2017/01/26/handle-inbound-text-speech-phone-call-node-js-dr/) | [receive-call-webhook.js](voice/receive-call-webhook.js) |
+| [How to Direct Inbound Phone Calls to an Endpoint with Failover with Node.js]| [receive-call-webhook-failover.js](voice/receive-call-webhook-failover.js) |
 | [How to Record Audio from Incoming Calls with Node.js](https://www.nexmo.com/blog/2017/02/06/how-to-record-audio-from-phone-call-node-js-dr/) | [record-call.js](voice/record-call.js)   |
 | [[How to Make a Private Phone Call with Node.js](https://www.nexmo.com/blog/2017/03/21/make-private-phone-call-node-js-dr/) | [proxy-call.js](https://github.com/nexmo-community/nexmo-node-quickstart/blob/master/voice/proxy-call.js) |
 

--- a/voice/receive-call-webhook-failover.js
+++ b/voice/receive-call-webhook-failover.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const app = require('express')();
+const bodyParser = require('body-parser');
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+const server = app.listen(process.env.PORT || 4001, () => {
+  console.log('Express server listening on port %d in %s mode', server.address().port, app.settings.env);
+});
+
+app.get('/answer', (req, res) => {
+  let from = req.query.from;
+  let to = req.query.to;
+
+  const ncco = [
+    {
+      "action": "connect",
+      "timeout": 5,
+      "from": from,
+      "eventType": "synchronous",
+      "endpoint": [
+        {
+          "type": "sip",
+          "uri": "sip:12065551212@sip.example.com"
+        }
+      ]
+    }
+  ];
+
+  res.json(ncco);
+});
+
+app.post('/event', (req, res) => {
+  console.log(req.body);
+  var fallbackEvents=['timeout','failed','unanswered','busy','rejected'];
+  if (fallbackEvents.indexOf(req.body.status)>-1) {
+    const ncco = [
+      {
+        "action": "connect",
+        "timeout": 60,
+        "from": req.body.from,
+        "eventType": "synchronous",
+        "endpoint": [
+          {
+            "type": "phone",
+            "number": "+12065551212"
+          }
+        ]
+      }
+    ];
+    res.json(ncco);
+  }
+  else res.status(204).end();
+});


### PR DESCRIPTION
Builds on receive-call-webhook.js to act as a forwarding app to send the inbound phone call to an endpoint. If the transfer fails, it sends the call to another endpoint.