### PR TITLE
WhatsApp should be number not ID.

### DIFF
--- a/dispatch/send-failover-sms-whatsapp.js
+++ b/dispatch/send-failover-sms-whatsapp.js
@@ -19,7 +19,7 @@ const nexmo = new Nexmo({
 
 nexmo.dispatch.create("failover", [
   {
-    "from": { "type": "whatsapp", "id": "WHATSAPP_NUMBER"},
+    "from": { "type": "whatsapp", "number": "WHATSAPP_NUMBER"},
     "to": { "type": "whatsapp", "number": "TO_NUMBER"},
     "message": {
       "content": {


### PR DESCRIPTION
## Description

Double checking against Messages API, WhatsApp is a number not an ID.