### PR TITLE
Minor updates for SMS examples

### DIFF
--- a/sms/README.md
+++ b/sms/README.md
@@ -19,6 +19,14 @@ To run "send" examples, just set up your ENV and run locally.
 
 To run "receive" examples, you need to run the webhook file on a server, or tunnel from your local server using the services like [ngrok](https://ngrok.com/). See the tutorials for more details.
 
+### Webhooks
+
+These simple examples will receive webhooks and output information to the console so you can see the data that was received.
+
+For incoming SMSes, configure your webhook to point to `/webhooks/incoming-sms`.
+
+To receive delivery receipts (DLRs), configure your webhook to point to `/webhooks/delivery-receipt`.
+
 ## Tutorials
 
 ### SMS

--- a/sms/dlr-express.js
+++ b/sms/dlr-express.js
@@ -15,4 +15,4 @@ function handleDeliveryReceipt(request, response) {
   response.status(204).send()
 }
 
-app.listen(3000)
+app.listen(process.env.PORT || 3000)

--- a/sms/receive-express.js
+++ b/sms/receive-express.js
@@ -15,4 +15,4 @@ function handleInboundSms(request, response) {
   response.status(204).send()
 }
 
-app.listen(3000)
+app.listen(process.env.PORT || 3000)

--- a/sms/send-express.js
+++ b/sms/send-express.js
@@ -18,7 +18,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 const server = app.listen(process.env.PORT || 3000);
 
 const nexmo = new Nexmo({
-  apiKey: NEXMO_.API_KEY,
+  apiKey: NEXMO_API_KEY,
   apiSecret: NEXMO_API_SECRET,
 }, {debug: true});
 

--- a/sms/send-unicode-sms.js
+++ b/sms/send-unicode-sms.js
@@ -2,7 +2,8 @@ require('dotenv').config({path: __dirname + '/../.env'})
 
 const NEXMO_API_KEY = process.env.NEXMO_API_KEY
 const NEXMO_API_SECRET = process.env.NEXMO_API_SECRET
-const TO_NUMBER = process.env.TO_NUMBER
+const TO_NUMBER = process.env.NEXMO_TO_NUMBER
+const FROM_NUMBER = process.env.NEXMO_FROM_NUMBER
 
 const Nexmo = require('nexmo')
 
@@ -11,7 +12,7 @@ const nexmo = new Nexmo({
   apiSecret: NEXMO_API_SECRET
 })
 
-const from = 'Acme Inc'
+const from = FROM_NUMBER
 const to = TO_NUMBER
 const text = 'こんにちは世界'
 const opts = {

--- a/sms/send.js
+++ b/sms/send.js
@@ -2,7 +2,8 @@ require('dotenv').config({path: __dirname + '/../.env'})
 
 const NEXMO_API_KEY = process.env.NEXMO_API_KEY
 const NEXMO_API_SECRET = process.env.NEXMO_API_SECRET
-const TO_NUMBER = process.env.TO_NUMBER
+const TO_NUMBER = process.env.NEXMO_TO_NUMBER
+const FROM_NUMBER = process.env.NEXMO_FROM_NUMBER
 
 const Nexmo = require('nexmo')
 
@@ -11,7 +12,7 @@ const nexmo = new Nexmo({
   apiSecret: NEXMO_API_SECRET
 })
 
-const from = 'Acme Inc'
+const from = FROM_NUMBER
 const to = TO_NUMBER
 const text = 'A text message sent using the Nexmo SMS API'
 


### PR DESCRIPTION
Fixes a typo that was breaking an example, makes port number configurable, switches the examples over to `NEXMO_TO_NUMBER` since the `.env` was updated and also sends from the `NEXMO_FROM_NUMBER` rather than a string. Oh, and a little documentation. All in different commits in case that's not what you wanted!