### PR TITLE
Fix variable initialisation for Verify demo

### DIFF
--- a/verify/request.js
+++ b/verify/request.js
@@ -13,8 +13,6 @@ const nexmo = new Nexmo({
   apiSecret: NEXMO_API_SECRET
 });
 
-let verifyRequestId = null; // use in the check process
-
 nexmo.verify.request({
   number: RECIPIENT_NUMBER,
   brand: NEXMO_BRAND_NAME
@@ -22,7 +20,7 @@ nexmo.verify.request({
   if (err) {
     console.error(err);
   } else {
-    verifyRequestId = result.request_id;
+    const verifyRequestId = result.request_id;
     console.log('request_id', verifyRequestId);
   }
 });


### PR DESCRIPTION
Moved verifyRequestId from `let` to `const`. 

The `let` part does not show up on the docs pages - https://developer.nexmo.com/verify/building-blocks/send-verify-request