### PR TITLE
Update to MMS failover example

### DIFF
--- a/dispatch/send-failover-sms-mms.js
+++ b/dispatch/send-failover-sms-mms.js
@@ -29,7 +29,7 @@ nexmo.dispatch.create("failover", [
     },
     "failover":{
       "expiry_time": 600,
-      "condition_status": "read"
+      "condition_status": "delivered"
     }
   },
   {


### PR DESCRIPTION
Make a change at the request of product to have the failover trigger on 'delivered' rather than 'read;