### PR TITLE
Change body-parser to express

### DIFF
--- a/messages/inbound-message.js
+++ b/messages/inbound-message.js
@@ -1,10 +1,9 @@
 'use strict';
 const express = require('express');
-const bodyParser = require('body-parser');
 const app = express();
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 app.post('/webhooks/inbound-message', (req, res) => {
   console.log(req.body);

--- a/messages/message-status.js
+++ b/messages/message-status.js
@@ -1,10 +1,9 @@
 'use strict';
 const express = require('express');
-const bodyParser = require('body-parser');
 const app = express();
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 app.post('/webhooks/message-status', (req, res) => {
   console.log(req.body);

--- a/messages/signed-webhooks/verify-signed-webhook.js
+++ b/messages/signed-webhooks/verify-signed-webhook.js
@@ -2,14 +2,14 @@ require('dotenv').config({ path: __dirname + '/../.env' })
 const VONAGE_API_SIGNATURE_SECRET = process.env.VONAGE_API_SIGNATURE_SECRET || ''
 const jwt = require("jsonwebtoken");
 const sha256 = require('js-sha256');
-const app = require('express')()
-const bodyParser = require('body-parser')
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({
+const express = require('express');
+const app = express()
+app.use(express.json())
+app.use(express.urlencoded({
   extended: true
 }))
 app
-    .route('/webhooks/inbound-message')    
+    .route('/webhooks/inbound-message')
     .post(handleInboundMessage);
 function handleInboundMessage(request, response){
     const payload = Object.assign(request.query, request.body)

--- a/messages/webhook-server.js
+++ b/messages/webhook-server.js
@@ -1,10 +1,9 @@
 'use strict';
 const express = require('express');
-const bodyParser = require('body-parser');
 const app = express();
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 app.post('/webhooks/inbound-message', (req, res) => {
   console.log(req.body);

--- a/number_insight/ni-advanced-async.js
+++ b/number_insight/ni-advanced-async.js
@@ -1,8 +1,8 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express')
+const app = express()
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({
+app.use(express.json())
+app.use(express.urlencoded({
   extended: true
 }))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,38 +75,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
-      },
-      "dependencies": {
-        "on-finished": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-          "requires": {
-            "ee-first": "1.1.1"
-          }
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        }
-      }
-    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -438,14 +406,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -674,17 +634,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
-        "unpipe": "1.0.0"
-      }
     },
     "request": {
       "version": "2.88.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.18.3",
     "dotenv": "^6.1.0",
     "ejs": "^2.6.1",
     "express": "^4.16.3",

--- a/sms/dlr-express.js
+++ b/sms/dlr-express.js
@@ -1,8 +1,8 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express')
+const app = express()
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 app
   .route('/webhooks/delivery-receipt')

--- a/sms/receive-express.js
+++ b/sms/receive-express.js
@@ -1,8 +1,8 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express')
+const app = express()
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
 
 app
   .route('/webhooks/inbound-sms')

--- a/sms/send-express.js
+++ b/sms/send-express.js
@@ -9,12 +9,11 @@ const VONAGE_API_SECRET = process.env.VONAGE_API_SECRET;
 const VONAGE_FROM_NUMBER = process.env.VONAGE_FROM_NUMBER;
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const Vonage = require('@vonage/server-sdk');
 
 const app = express();
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 const server = app.listen(process.env.PORT || 3000);
 
 const vonage = new Vonage({

--- a/sms/verify-signed-sms-express.js
+++ b/sms/verify-signed-sms-express.js
@@ -4,11 +4,11 @@ const VONAGE_API_SIGNATURE_SECRET = process.env.VONAGE_API_SIGNATURE_SECRET
 
 const Vonage = require('@vonage/server-sdk')
 
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express');
+const app = express()
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({
+app.use(express.json())
+app.use(express.urlencoded({
   extended: true
 }))
 

--- a/verify/2fa.js
+++ b/verify/2fa.js
@@ -18,12 +18,11 @@ require('dotenv').config({
 });
 
 const express = require('express');
-const bodyParser = require('body-parser');
 const ejs = require('ejs');
 const app = express();
 
-app.use(bodyParser.json()); // for parsing POST req
-app.use(bodyParser.urlencoded({
+app.use(express.json()); // for parsing POST req
+app.use(express.urlencoded({
   extended: true
 }));
 

--- a/voice/answer-webhook-endpoint.js
+++ b/voice/answer-webhook-endpoint.js
@@ -2,9 +2,10 @@
 
 require('dotenv').config({path: __dirname + '/../.env'});
 
-var app = require('express')();
+var express = require('express');
+var app = express();
 app.set('port', (process.env.PORT || 5000));
-app.use(require('body-parser').urlencoded({ extended: false }));
+app.use(express.urlencoded({ extended: false }));
 
 app.get('/answer-webhook', function (req, res) {
   var from = req.query.from;

--- a/voice/asr.js
+++ b/voice/asr.js
@@ -1,7 +1,7 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express');
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [{

--- a/voice/conference-call.js
+++ b/voice/conference-call.js
@@ -1,10 +1,10 @@
 require('dotenv').config({path: __dirname + '/../.env'})
 const CONF_NAME = process.env.CONF_NAME
 
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express');
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [

--- a/voice/connect-synchronous.js
+++ b/voice/connect-synchronous.js
@@ -6,10 +6,10 @@ const VONAGE_FROM_NUMBER = process.env.VONAGE_FROM_NUMBER;
 const VONAGE_TO_NUMBER = process.env.VONAGE_TO_NUMBER;
 const VONAGE_ALT_NUMBER = process.env.VONAGE_ALT_NUMBER;
 
-const app = require('express')();
-const bodyParser = require('body-parser');
+const express = require('express');
+const app = express();
 
-app.use(bodyParser.json());
+app.use(express.json());
 app.set('port', (process.env.PORT || 5000));
 
 app.get('/answer', function (req, res) {
@@ -30,21 +30,21 @@ app.get('/answer', function (req, res) {
 
   console.log('Returning NCCO');
   console.dir(ncco)
-  
+
   res.json(ncco);
-  
+
 });
 
 app.post('/connect-event', function(req, res) {
   const ncco = [];
-  
+
   if(req.body.status === 'timeout') {
     // Note: you cannot presently do this
     // ncco.push({
     //   action: 'talk',
     //   text: 'Sorry, the attempt to connect your call timed out.'
     // });
-    
+
     ncco.push({
         action: 'connect',
         from: VONAGE_FROM_NUMBER,
@@ -54,7 +54,7 @@ app.post('/connect-event', function(req, res) {
         }]
       });
   }
-  
+
   res.json(ncco);
 });
 

--- a/voice/dtmf.js
+++ b/voice/dtmf.js
@@ -1,7 +1,7 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express');
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [

--- a/voice/ivr-menu.js
+++ b/voice/ivr-menu.js
@@ -1,7 +1,7 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express')
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 app.get('/webhooks/answer', (req, res) => {
   const ncco = [{

--- a/voice/proxy-call.js
+++ b/voice/proxy-call.js
@@ -4,10 +4,10 @@
 
 'use strict';
 require('dotenv').config({path: __dirname + '/../.env'});
-const app = require('express')();
-const bodyParser = require('body-parser');
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 const VONAGE_FROM_NUMBER = process.env.VONAGE_FROM_NUMBER;
 const VONAGE_TO_NUMBER = process.env.VONAGE_TO_NUMBER;

--- a/voice/receive-call-webhook-failover.js
+++ b/voice/receive-call-webhook-failover.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const app = require('express')();
-const bodyParser = require('body-parser');
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 const server = app.listen(process.env.PORT || 4001, () => {
   console.log('Express server listening on port %d in %s mode', server.address().port, app.settings.env);

--- a/voice/record-a-call-with-split-audio.js
+++ b/voice/record-a-call-with-split-audio.js
@@ -4,10 +4,10 @@ require('dotenv').config({path: __dirname + '/../.env'})
 const TO_NUMBER = process.env.TO_NUMBER
 const VONAGE_NUMBER = process.env.VONAGE_NUMBER
 
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express')
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [{

--- a/voice/record-a-call.js
+++ b/voice/record-a-call.js
@@ -4,10 +4,10 @@ require('dotenv').config({path: __dirname + '/../.env'})
 const TO_NUMBER = process.env.TO_NUMBER
 const VONAGE_NUMBER = process.env.VONAGE_NUMBER
 
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express')
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [{

--- a/voice/record-a-conversation.js
+++ b/voice/record-a-conversation.js
@@ -3,10 +3,10 @@ require('dotenv').config({path: __dirname + '/../.env'})
 
 const CONF_NAME = process.env.CONF_NAME
 
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express');
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [{

--- a/voice/record-a-message.js
+++ b/voice/record-a-message.js
@@ -1,7 +1,7 @@
-const app = require('express')()
-const bodyParser = require('body-parser')
+const express = require('express');
+const app = express()
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 const onInboundCall = (request, response) => {
   const ncco = [{

--- a/voice/send-dtmf-to-call.js
+++ b/voice/send-dtmf-to-call.js
@@ -10,10 +10,10 @@ const VONAGE_APPLICATION_ID = process.env.VONAGE_APPLICATION_ID;
 const TO_NUMBER = process.env.VONAGE_TO_NUMBER;
 const FROM_NUMBER = process.env.VONAGE_FROM_NUMBER;
 
-const app = require('express')();
-const bodyParser = require('body-parser');
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({
+const express = require('express');
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({
   extended: true
 }));
 


### PR DESCRIPTION
This pull request closes #93.

Many of the examples were using the outdated `body-parser` package. This has been changed so as to use the `express` built-in alternatives.