### PR TITLE
DEVX-6440: Updating whatsapp template snippets

### DIFF
--- a/messages/whatsapp/send-media-template.js
+++ b/messages/whatsapp/send-media-template.js
@@ -49,18 +49,9 @@ vonage.messages.send(
 				{
 					type: 'body',
 					parameters: [
-						{
-							type: 'text',
-							text: 'Value 1',
-						},
-						{
-							type: 'text',
-							text: 'Value 2',
-						},
-						{
-							type: 'text',
-							text: 'Value 3',
-						},
+						'Value 1',
+						'Value 2',
+						'Value 3',
 					],
 				},
 			],

--- a/messages/whatsapp/send-template.js
+++ b/messages/whatsapp/send-template.js
@@ -32,15 +32,9 @@ vonage.messages.send(
 		{
 			name: `${WHATSAPP_TEMPLATE_NAMESPACE}:${WHATSAPP_TEMPLATE_NAME}`,
 			parameters: [
-				{
-					default: 'Vonage Verification',
-				},
-				{
-					default: '64873',
-				},
-				{
-					default: '10',
-				},
+				'Vonage Verification',
+			    '64873',
+				'10',
 			],
 		},
 		{


### PR DESCRIPTION
Small change to the snippets for sending WhatsApp Template messages. The value for the `parameters` field was incorrect due to an error in the spec.