### PR TITLE
Fix messageType in Messages API SMS Sample

### DIFF
--- a/messages/sms/send-sms-basic-auth.js
+++ b/messages/sms/send-sms-basic-auth.js
@@ -26,7 +26,7 @@ const vonage = new Vonage(
 );
 
 vonage.messages.send({
-  messageType: 'sms',
+  messageType: 'text',
   channel: Channels.SMS,
   text: 'This is an SMS text message sent using the Messages API',
   to: MESSAGES_TO_NUMBER,

--- a/messages/sms/send-sms.js
+++ b/messages/sms/send-sms.js
@@ -26,7 +26,7 @@ const vonage = new Vonage(
 );
 
 vonage.messages.send({
-  messageType: 'sms',
+  messageType: 'text',
   channel: Channels.SMS,
   text: 'This is an SMS text message sent using the Messages API',
   to: MESSAGES_TO_NUMBER,


### PR DESCRIPTION
The current code snippet for sending an SMS with the Messages API sets `messageType` to "sms", while the Messages API expects "text".

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current code snippet for sending an SMS with the Messages API sets `messageType` to "sms", while the Messages API expects "text".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current code snippets for sending an SMS via the Messages API fail.
<!--- If it fixes an open issue, please link to the issue here. -->
Applying this change results in working code.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Example Output(if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] All new and existing tests passed.
